### PR TITLE
CI: add least-privilege permissions to GitHub Actions workflows

### DIFF
--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -6,6 +6,10 @@ on:
   pull_request:
     branches: [ main ]
 
+permissions:
+  contents: read
+  pull-requests: read
+
 jobs:
   lint:
     name: Spotless check

--- a/.github/workflows/baseline-profile.yml
+++ b/.github/workflows/baseline-profile.yml
@@ -23,6 +23,11 @@ on:
 # Read more at https://docs.github.com/en/actions/security-guides/encrypted-secrets
 
 # Jobs to executed on GitHub machines
+
+permissions:
+  contents: read
+  pull-requests: write
+
 jobs:
 
   # Job name


### PR DESCRIPTION
## Summary
- Add explicit least-privilege `permissions` blocks to workflow files flagged by CodeQL.
- Scopes derived from workflow operations (build, artifacts, Danger, release git push).
- Resolves **3** open `actions/missing-workflow-permissions` alerts.

## Linear
- Parent: [APPSEC-164](https://linear.app/stream/issue/APPSEC-164)

## Test plan
- [ ] CI green
- [ ] Code scanning alerts close after merge
